### PR TITLE
refactor: update client methods to not return OK string

### DIFF
--- a/client/auth_methods.go
+++ b/client/auth_methods.go
@@ -2,14 +2,14 @@ package client
 
 import "mini-redis/types/commands"
 
-func (c *RedisClient) Auth(user string, password string) (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) Auth(user string, password string) error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.AUTH).AddParam(user).AddParam(password),
 	)
 }
 
-func (c *RedisClient) Logout() (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) Logout() error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.LOGOUT),
 	)
 }
@@ -37,14 +37,14 @@ func (c *RedisClient) UserGet(users ...string) (string, error) {
 	)
 }
 
-func (c *RedisClient) AddRule(user string, rules ...string) (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) AddRule(user string, rules ...string) error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.ADDRULE).AddParam(user).AddParamSlice(rules...),
 	)
 }
 
-func (c *RedisClient) RmRule(user string, rules ...string) (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) RmRule(user string, rules ...string) error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.RMRULE).AddParam(user).AddParamSlice(rules...),
 	)
 }

--- a/client/init.go
+++ b/client/init.go
@@ -44,12 +44,12 @@ func NewClient(opt *ClientOptions) (*RedisClient, error) {
 				return nil, fmt.Errorf("failed to parse db number")
 			}
 
-			_, err = c.Select(dbIdx)
+			err = c.Select(dbIdx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to switch to db %d", dbIdx)
 			}
 		}
-		_, err := c.Auth(username, pass)
+		err := c.Auth(username, pass)
 		if err != nil {
 			return nil, fmt.Errorf("failed to authenticate")
 		}

--- a/client/methods.go
+++ b/client/methods.go
@@ -19,8 +19,8 @@ func (c *RedisClient) Echo(msg string) (string, error) {
 	)
 }
 
-func (c *RedisClient) Set(key string, value string) (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) Set(key string, value string) error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.SET).AddParam(key).AddParam(value),
 	)
 }
@@ -31,8 +31,8 @@ func (c *RedisClient) Get(key string) (string, error) {
 	)
 }
 
-func (c *RedisClient) Del(key string) (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) Del(key string) error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.DEL).AddParam(key),
 	)
 }
@@ -72,14 +72,14 @@ func (c *RedisClient) Decr(key string) (int, error) {
 	)
 }
 
-func (c *RedisClient) FlushAll() (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) FlushAll() error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.FLUSHALL),
 	)
 }
 
-func (c *RedisClient) FlushDB() (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) FlushDB() error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.FLUSHDB),
 	)
 }
@@ -108,14 +108,14 @@ func (c *RedisClient) ExpireTime(key string) (int, error) {
 	)
 }
 
-func (c *RedisClient) Save() (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) Save() error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.SAVE),
 	)
 }
 
-func (c *RedisClient) Load(idx int) (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) Load(idx int) error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.LOAD).AddParamInt(idx),
 	)
 }
@@ -126,14 +126,14 @@ func (c *RedisClient) ListSaves() (string, error) {
 	)
 }
 
-func (c *RedisClient) RmSave(idx int) (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) RmSave(idx int) error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.RMSAVE).AddParamInt(idx),
 	)
 }
 
-func (c *RedisClient) Select(idx int) (string, error) {
-	return c.SendAndReceive(
+func (c *RedisClient) Select(idx int) error {
+	return c.SendAndReceiveErr(
 		InitRequest(commands.SELECT).AddParamInt(idx),
 	)
 }

--- a/client/request.go
+++ b/client/request.go
@@ -124,6 +124,11 @@ func (c *RedisClient) SendAndReceive(req *RequestBuilder) (string, error) {
 	return "", fmt.Errorf("unknown RESP type returned")
 }
 
+func (c *RedisClient) SendAndReceiveErr(req *RequestBuilder) error {
+	_, err := c.SendAndReceive(req)
+	return err
+}
+
 func (c *RedisClient) SendAndReceiveList(req *RequestBuilder) ([]string, error) {
 	result, resType, err := c.makeRequest(req)
 

--- a/test/benchmark/benchmark_test.go
+++ b/test/benchmark/benchmark_test.go
@@ -15,7 +15,7 @@ func setupAndFlush() (*client.RedisClient, error) {
 		return nil, err
 	}
 
-	_, err = c.FlushAll()
+	err = c.FlushAll()
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func BenchmarkGetAndSet(b *testing.B) {
 
 	// simple write/read loop
 	for b.Loop() {
-		_, err = c.Set("hello", "hello")
+		err = c.Set("hello", "hello")
 		if err != nil {
 			b.Fatal("Set call failed")
 		}

--- a/test/default_methods_test.go
+++ b/test/default_methods_test.go
@@ -32,31 +32,39 @@ func TestEcho(t *testing.T) {
 func TestSet(t *testing.T) {
 	c := setupAndFlush(t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err := c.Set("test", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 }
 
 func TestGet(t *testing.T) {
 	c := setupAndFlush(t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err := c.Set("test", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
-	s, err = c.Get("test")
+	s, err := c.Get("test")
 	checkExpect(s, err, commands.GET, "TEST", t)
 }
 
 func TestDelete(t *testing.T) {
 	c := setupAndFlush(t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err := c.Set("test", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
-	s, err = c.Get("test")
+	s, err := c.Get("test")
 	checkExpect(s, err, commands.GET, "TEST", t)
 
-	s, err = c.Del("test")
-	checkExpect(s, err, commands.GET, "OK", t)
+	err = c.Del("test")
+	if err != nil {
+		t.Errorf("DEL command returned an error: %e", err)
+	}
 
 	s, err = c.Get("test")
 	checkExpect(s, err, commands.GET, "", t)
@@ -65,8 +73,10 @@ func TestDelete(t *testing.T) {
 func TestFlushAll(t *testing.T) {
 	c := setup(t)
 
-	s, err := c.FlushAll()
-	checkExpect(s, err, commands.FLUSHALL, "OK", t)
+	err := c.FlushAll()
+	if err != nil {
+		t.Errorf("FLUSHALL command returned an error: %e", err)
+	}
 }
 
 func TestEmptyGet(t *testing.T) {
@@ -79,13 +89,17 @@ func TestEmptyGet(t *testing.T) {
 func TestExists(t *testing.T) {
 	c := setupAndFlush(t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err := c.Set("test", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
-	s, err = c.Set("test2", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err = c.Set("test2", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
-	s, err = c.Exists("test")
+	s, err := c.Exists("test")
 	checkExpect(s, err, commands.EXISTS, "1", t)
 
 	s, err = c.Exists("test", "test2")
@@ -98,8 +112,10 @@ func TestExpire(t *testing.T) {
 	s, err := c.Expire("awidawbnd", 10)
 	checkExpect(s, err, commands.EXPIRE, "0", t)
 
-	s, err = c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err = c.Set("test", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
 	s, err = c.Expire("test", 10)
 	checkExpect(s, err, commands.EXPIRE, "1", t)
@@ -111,8 +127,10 @@ func TestTTL(t *testing.T) {
 	s, err := c.TTL("test")
 	checkExpect(s, err, commands.TTL, "-2", t)
 
-	s, err = c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err = c.Set("test", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
 	s, err = c.TTL("test")
 	checkExpect(s, err, commands.TTL, "-1", t)
@@ -135,19 +153,23 @@ func TestIncr(t *testing.T) {
 	i, err := c.Incr("test")
 	checkExpect(i, err, commands.INCR, 1, t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err = c.Set("test", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
 	i, err = c.Incr("test")
 	checkError(i, err, commands.INCR, errors.NOT_INTEGER.Error(), t)
 
-	s, err = c.Set("test", "1")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err = c.Set("test", "1")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
 	i, err = c.Incr("test")
 	checkExpect(i, err, commands.INCR, 2, t)
 
-	s, err = c.Get("test")
+	s, err := c.Get("test")
 	checkExpect(s, err, commands.GET, "2", t)
 }
 
@@ -157,19 +179,23 @@ func TestDecr(t *testing.T) {
 	i, err := c.Decr("test")
 	checkExpect(i, err, commands.DECR, -1, t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err = c.Set("test", "TEST")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
 	i, err = c.Decr("test")
 	checkError(i, err, commands.DECR, errors.NOT_INTEGER.Error(), t)
 
-	s, err = c.Set("test", "1")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err = c.Set("test", "1")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
 	i, err = c.Decr("test")
 	checkExpect(i, err, commands.DECR, 0, t)
 
-	s, err = c.Get("test")
+	s, err := c.Get("test")
 	checkExpect(s, err, commands.GET, "0", t)
 }
 
@@ -180,8 +206,10 @@ func TestKeys(t *testing.T) {
 	for i := range 5 {
 		key := fmt.Sprintf("test-%d", i)
 		setKeys[i] = key
-		res, err := c.Set(key, "1")
-		checkExpect(res, err, commands.SET, "OK", t)
+		err := c.Set(key, "1")
+		if err != nil {
+			t.Errorf("SET command returned error: %e", err)
+		}
 	}
 
 	keys, err := c.Keys()
@@ -209,8 +237,10 @@ func TestExpireAtTime(t *testing.T) {
 	respInt, err := c.ExpireTime("hello")
 	checkExpect(respInt, err, commands.EXPIRETIME, -2, t)
 
-	resp, err := c.Set("hello", "hello")
-	checkExpect(resp, err, commands.SET, "OK", t)
+	err = c.Set("hello", "hello")
+	if err != nil {
+		t.Errorf("SET command returned error: %e", err)
+	}
 
 	respInt, err = c.ExpireTime("hello")
 	checkExpect(respInt, err, commands.EXPIRETIME, -1, t)

--- a/test/list_methods_test.go
+++ b/test/list_methods_test.go
@@ -10,8 +10,10 @@ import (
 func TestLPush(t *testing.T) {
 	c := setupAndFlush(t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err := c.Set("test", "TEST")
+	if err != nil {
+		fmt.Printf("SET returned error: %e", err)
+	}
 
 	respInt, err := c.LPush("test", "test")
 	checkError(respInt, err, commands.LPUSH, errors.WRONGTYPE.Error(), t)
@@ -21,15 +23,17 @@ func TestLPush(t *testing.T) {
 		checkExpect(respInt, err, commands.LPUSH, i+1, t)
 	}
 
-	s, err = c.Get("test2")
+	s, err := c.Get("test2")
 	checkError(s, err, commands.GET, errors.WRONGTYPE.Error(), t)
 }
 
 func TestRPush(t *testing.T) {
 	c := setupAndFlush(t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err := c.Set("test", "TEST")
+	if err != nil {
+		fmt.Printf("SET returned error: %e", err)
+	}
 
 	respInt, err := c.RPush("test", "test")
 	checkError(respInt, err, commands.RPUSH, errors.WRONGTYPE.Error(), t)
@@ -39,15 +43,17 @@ func TestRPush(t *testing.T) {
 		checkExpect(respInt, err, commands.RPUSH, i+1, t)
 	}
 
-	s, err = c.Get("test2")
+	s, err := c.Get("test2")
 	checkError(s, err, commands.GET, errors.WRONGTYPE.Error(), t)
 }
 
 func TestLPopOne(t *testing.T) {
 	c := setupAndFlush(t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err := c.Set("test", "TEST")
+	if err != nil {
+		fmt.Printf("SET returned error: %e", err)
+	}
 
 	respArr, err := c.LPop("test")
 	checkError(respArr, err, commands.LPOP, errors.WRONGTYPE.Error(), t)
@@ -78,8 +84,10 @@ func TestLPopMany(t *testing.T) {
 func TestRPopOne(t *testing.T) {
 	c := setupAndFlush(t)
 
-	s, err := c.Set("test", "TEST")
-	checkExpect(s, err, commands.SET, "OK", t)
+	err := c.Set("test", "TEST")
+	if err != nil {
+		fmt.Printf("SET returned error: %e", err)
+	}
 
 	respArr, err := c.RPop("test")
 	checkError(respArr, err, commands.RPOP, errors.WRONGTYPE.Error(), t)

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -33,7 +33,7 @@ func setupAndFlush(t *testing.T) *client.RedisClient {
 			t.Errorf("client initialization")
 		}
 
-		_, err = c.FlushAll()
+		err = c.FlushAll()
 		if err != nil {
 			t.Errorf("initial flush")
 		}
@@ -42,7 +42,7 @@ func setupAndFlush(t *testing.T) *client.RedisClient {
 		return c
 	}
 
-	_, err := globalClient.FlushAll()
+	err := globalClient.FlushAll()
 	if err != nil {
 		t.Errorf("initial flush")
 	}


### PR DESCRIPTION
Removed (string, error) on many function signatures, replaced with (error), since the string was just "OK"